### PR TITLE
Add gofmt_command option

### DIFF
--- a/autoload/go/format.vim
+++ b/autoload/go/format.vim
@@ -13,7 +13,7 @@ function! go#format#Run(...)
   try
     let view = winsaveview()
 
-    let gofmt = 'gofmt'
+    let gofmt = g:gofmt_command
     if simplify
       let gofmt .= ' -s'
     endif

--- a/doc/golang.txt
+++ b/doc/golang.txt
@@ -155,6 +155,12 @@ go_highlight_trailing_whitespace_error ~
 
     Highlights trailing white space.
 
+*g:gofmt_command*
+
+Set the command to use when calling |Fmt|:
+
+   let g:gofmt_command = 'gofmt'
+
 ==============================================================================
 ISSUES                                                           *golang-issues*
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -2,6 +2,10 @@ if exists("b:did_ftplugin")
   finish
 endif
 
+if !exists("g:gofmt_command")
+    let g:gofmt_command = "gofmt"
+endif
+
 set includeexpr=go#FindFile(v:fname)
 
 command! -buffer A  exe 'edit '           . go#TestFile()


### PR DESCRIPTION
It helps in case you want to use [goimports](https://godoc.org/code.google.com/p/go.tools/cmd/goimports) for example.

I consider it a draft since there are no docs and maybe I'm missing something else too. 
- Should I add something else apart from docs?
- Is there are a reason why the other options we have don't follow the usual convention of `g:plugin_foo` (I might be wrong about considering it a convention my experience with vim plugins is pretty limited)
